### PR TITLE
Bump org.thymeleaf.extras:thymeleaf-extras-springsecurity6

### DIFF
--- a/custom-login/pom.xml
+++ b/custom-login/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity6</artifactId>
-            <version>3.1.1.RELEASE</version>
+            <version>3.1.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/okta-hosted-login/pom.xml
+++ b/okta-hosted-login/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.thymeleaf.extras</groupId>
             <artifactId>thymeleaf-extras-springsecurity6</artifactId>
-            <version>3.1.1.RELEASE</version>
+            <version>3.1.2.RELEASE</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Bumps org.thymeleaf.extras:thymeleaf-extras-springsecurity6 from 3.1.1.RELEASE to 3.1.2.RELEASE.

---
updated-dependencies:
- dependency-name: org.thymeleaf.extras:thymeleaf-extras-springsecurity6 dependency-type: direct:production update-type: version-update:semver-patch ...